### PR TITLE
Update PhotoCollage to 1.4.6

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,40 @@
+diff --git a/data/photocollage.appdata.xml b/data/photocollage.appdata.xml
+index 98cdae6..d95d192 100644
+--- a/data/photocollage.appdata.xml
++++ b/data/photocollage.appdata.xml
+@@ -1,10 +1,12 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<application>
+- <id type="desktop">photocollage.desktop</id>
++<component type="desktop">
++ <id>photocollage.desktop</id>
+  <metadata_license>CC-BY-3.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>PhotoCollage</name>
+- <content_rating type="oars-1.0" />
++ <developer_name>Adrien Vergé</developer_name>
++ <launchable type="desktop-id">io.github.adrienverge.PhotoCollage.desktop</launchable>
++ <content_rating type="oars-1.1" />
+  <summary>Graphical tool to make photo collage posters</summary>
+  <summary xml:lang="cs">Grafický nástroj pro vytváření koláží z fotografií</summary>
+  <summary xml:lang="de">Grafisches Werkzeug zum erstellen von Foto-Collagen Poster</summary>
+@@ -175,12 +177,13 @@
+  </description>
+  <screenshots>
+   <screenshot type="default" width="800" height="450">
+-   https://github.com/adrienverge/PhotoCollage/raw/v1.4.0/screenshots/photocollage-1.4-preview.png
++    <image>https://github.com/adrienverge/PhotoCollage/raw/v1.4.0/screenshots/photocollage-1.4-preview.png</image>
+   </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/adrienverge/PhotoCollage</url>
+- <updatecontact>adrienverge_at_gmail.com</updatecontact>
++ <url type="vcs-browser">https://github.com/adrienverge/PhotoCollage</url>
++ <update_contact>adrienverge_at_gmail.com</update_contact>
+  <releases>
+    <release version="1.4.5" date="2021-07-09" />
+  </releases>
+-</application>
++</component>
+--
+libgit2 1.7.2
+

--- a/io.github.adrienverge.PhotoCollage.yml
+++ b/io.github.adrienverge.PhotoCollage.yml
@@ -1,6 +1,6 @@
 app-id: io.github.adrienverge.PhotoCollage
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 rename-icon: photocollage
 rename-appdata-file: photocollage.appdata.xml
@@ -20,6 +20,8 @@ modules:
     build-commands:
       - pip3 install --prefix /app --no-deps .
     sources:
-      - type: git
-        url: https://github.com/adrienverge/PhotoCollage.git
-        commit: d5a6f2bc7d9d6620427edc937639f384a893202c
+      - type: archive
+        url: https://github.com/adrienverge/PhotoCollage/archive/refs/tags/v1.4.6.tar.gz
+        sha256: 4a49b97443ebe6a1823d77991d15230882cfa6c78402c923785b0838e80ba1ae
+      - type: patch
+        path: fix_appdata.patch


### PR DESCRIPTION
- Update PhotoCollage to 1.4.6
- Update PhotoCollage runtime to 46
- Fix appdata papercuts